### PR TITLE
Update top and left spacing for close UIButton.

### DIFF
--- a/public/css/guide.css
+++ b/public/css/guide.css
@@ -41,7 +41,7 @@ body {
 
 ol,
 ul {
-  margin: 20px; }
+  margin: 16px; }
 
 p .bi {
   margin-right: 0; }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -794,8 +794,8 @@ li {
 
 .modal-content .modal-exit {
   position: absolute;
-  top: -25px;
-  right: -10px;
+  top: -7px;
+  right: -2px;
   color: #666c72; }
   .modal-content .modal-exit:hover {
     color: #323b43; }

--- a/src/scss/components/Modal.scss
+++ b/src/scss/components/Modal.scss
@@ -43,8 +43,8 @@
 
 .modal-content .modal-exit {
   position: absolute;
-  top: -25px;
-  right: -10px;
+  top: -7px;
+  right: -2px;
 
   color: $nevada;
 


### PR DESCRIPTION
### Purpose

Fix the whitespace surrounding the close `UIButton` for our modal objects. The space between the icon and the edges of the modal is now `16px`.
### Review

cc: @hamstu 

_Also a friendly reminder to label this PR with Code Review severity and status :smile:_
