### PR TITLE
Rename StaticPage.scss and fix `--pricing` modifier

### DIFF
--- a/src/scss/components/ExternalPage.scss
+++ b/src/scss/components/ExternalPage.scss
@@ -41,7 +41,7 @@
 }
 
 .BlockHero--pricing {
-  background-image: url(/img/block-title-text--hero@2x.png);
+  background-image: url(../img/block-title-text--hero@2x.png);
 }
 
 .BlockFooter {

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -12,6 +12,7 @@
 
 @import "components/Button";
 @import "components/Card";
+@import "components/ExternalPage";
 @import "components/GridSystem";
 @import "components/Input";
 @import "components/MetaBar";
@@ -19,5 +20,4 @@
 @import "components/Notification";
 @import "components/Post";
 @import "components/ProfilePicture";
-@import "components/StaticPage";
 @import "components/Tag"


### PR DESCRIPTION
### Purpose

This PR renames `StaticPage.scss` to `ExternalPage.scss` including its reference in `style.scss`. The background image gets fixed by prefixing `..` to its location.
### Things to Note

Nothing to note on this one! 👍 
### Review

**Some aspects to consider during review:**
- Functionality and Implementation
- Architecture and performance
- Code readability and style

_A friendly reminder to label this PR with severity, pending status and assign your reviewer :smile:_
