### PR TITLE
Update NavBar page link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="colors.html">Colors</a></li>
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="external-pages.html">External Pages</a></li>
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="grid-system.html">Grid System</a></li>
-        <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="navbars.html">NavBars</a></li>
+        <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="navbar.html">NavBars</a></li>
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="profile-pictures.html">Profile Pictures</a></li>
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="tags.html">Tags</a></li>
         <li class="NavBar__menu__item NavBar__menu__item--last"><a class="NavBar__menu__item__link" href="typography.html">Typography</a></li>


### PR DESCRIPTION
Removing a trailing "s" at the end of the `NavBar` page link on `/index.html`.
