### PR TITLE
Fixing broken navigation on typography page

### DIFF
--- a/public/typography.html
+++ b/public/typography.html
@@ -24,7 +24,6 @@
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="profile-pictures.html">Profile Pictures</a></li>
         <li class="NavBar__menu__item"><a class="NavBar__menu__item__link" href="tags.html">Tags</a></li>
         <li class="NavBar__menu__item NavBar__menu__item--active"><a class="NavBar__menu__item__link" href="typography.html">Typography</a></li>
-        <li class="NavBar__menu__item NavBar__menu__item--last"><a class="NavBar__menu__item__link" href="variables.html">Variables</a></li>
       </ul>
       <ul class="NavBar__right-menu">
         <li class="NavBar__menu__item NavBar__menu__item--last"><a class="Button Button--secondary" href="https://buffer.com/">Sign up for Free</a></li>
@@ -54,7 +53,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="Block Block--type-alternative">
       <div class="GridRow">
         <div class="GridContainer">
@@ -85,7 +84,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="Block Block--type-alternative">
       <div class="GridRow">
         <div class="GridContainer">
@@ -98,7 +97,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="Block">
       <div class="GridRow">
         <div class="GridContainer">
@@ -122,7 +121,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="Block Block--type-alternative">
       <div class="GridRow">
         <div class="GridContainer">


### PR DESCRIPTION
In `public` -> `typography.html` a new navigation item is introduced that links to a non-existing file. Furthermore, it affects the `NavBar` styling on the live site.

This commit eliminates that unnecessary reference to `variables.html`.

---

Current site screenshots:

<img width="1227" alt="buffer-style-current-desktop" src="https://user-images.githubusercontent.com/25587929/36345434-6d478c48-13e7-11e8-8ec8-2a1e96408ef5.png">
<img width="968" alt="buffer-style-current-desktop-2" src="https://user-images.githubusercontent.com/25587929/36345433-6d3038cc-13e7-11e8-9e20-64f4108ea284.png">